### PR TITLE
Add Python and F# applications to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Trying to cover all 'to-do-list' Application or Web Application using various pr
   <li><a href="https://github.com/serbelga/ToDometer">Kotlin</a></li>
   <li><a href="https://github.com/NisooJadhav/pern-todo">P(PostgreSQL)ERN Stack</a></li>
   <li><a href="https://github.com/pasimako/agitodo">PHP+Java+JS</a></li>
+  <li><a href="https://github.com/marcosvbras/todo-list-python">Python</li>
   <li><a href="https://github.com/NisooJadhav/react-todo">React</a></li>
   <li><a href="https://github.com/rogic89/ToDo-react-redux-immutable">React+Redux+ImmutableJS</a></li>
   <li><a href="https://github.com/mrhead/todos">Ruby/Ruby on Rails</a></li>
@@ -28,9 +29,10 @@ Trying to cover all 'to-do-list' Application or Web Application using various pr
   <li><a href="https://github.com/NisooJadhav/vuex-todo">Vuex</a></li>
 </ul>
 
-
 ## Contributing
+
 Pull requests are welcome.
 
 ## License
+
 [MIT](https://choosealicense.com/licenses/mit/)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Trying to cover all 'to-do-list' Application or Web Application using various pr
   <li><a href="https://github.com/NisooJadhav/to-do-list">EJS</a></li>
   <li><a href="https://github.com/rtzll/flask-todolist">Flask</a></li>
   <li><a href="https://github.com/prashant-shahi/ToDo-List-using-Flask-and-MongoDB">Flask+MongoDB</a></li>
+  <li><a href="https://github.com/mwyrebski/todofs">F#</a></li>
   <li><a href="https://github.com/schadokar/go-to-do-app">Go</a></li>
   <li><a href="https://github.com/Yalantis/ToDoList">Java</a></li>
   <li><a href="https://github.com/tusharnankani/ToDoList">JavaScript</a></li>


### PR DESCRIPTION
This PR addresses the issue https://github.com/NisooJadhav/to-dos-various-languages/issues/1

The following links have been added to the README.md
1. F#: https://github.com/mwyrebski/todofs
2. Python: https://github.com/marcosvbras/todo-list-python

